### PR TITLE
Pull in uswds prototype scaffolding

### DIFF
--- a/prototypes/form-wizard/.gitignore
+++ b/prototypes/form-wizard/.gitignore
@@ -1,3 +1,5 @@
 _site
 .sass-cache
 .jekyll-metadata
+node_modules
+npm-debug.log

--- a/prototypes/form-wizard/README.md
+++ b/prototypes/form-wizard/README.md
@@ -1,0 +1,30 @@
+# FOIA Form Wizard Prototype
+
+A Jekyll template for prototyping [US Web Design
+Standards][uswds-site] based websites.
+
+
+## Prerequisites
+
+This site uses [Jeykll][jekyll-site] to build and serve the website
+and [npm][npm-site] to manage dependencies.
+
+- Install npm with [Node][node-download]
+- Install [Jekyll][jekyll-site]
+
+
+## Usage
+
+Install the dependencies and start the development server.
+
+    $ npm install
+    $ npm run build
+    $ npm run serve
+
+Open your browser to [http://localhost:4000/](http://localhost:4000/).
+
+
+[jekyll-site]: https://jekyllrb.com/
+[node-download]: https://nodejs.org/en/download/
+[npm-site]: https://www.npmjs.com/
+[uswds-site]: https://standards.usa.gov/

--- a/prototypes/form-wizard/README.md
+++ b/prototypes/form-wizard/README.md
@@ -10,13 +10,14 @@ This site uses [Jeykll][jekyll-site] to build and serve the website
 and [npm][npm-site] to manage dependencies.
 
 - Install npm with [Node][node-download]
-- Install [Jekyll][jekyll-site]
+- Install [Bundler](https://bundler.io/) with `gem install bundler`
 
 
 ## Usage
 
 Install the dependencies and start the development server.
 
+    $ bundle install
     $ npm install
     $ npm run build
     $ npm run serve

--- a/prototypes/form-wizard/_config.yml
+++ b/prototypes/form-wizard/_config.yml
@@ -9,26 +9,28 @@
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
-title: Your awesome title
-email: your-email@domain.com
+title: FOIA request prototype
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  A prototype exploring how the public might submit a FOIA request through
+  a single national portal.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
+agency:
+  name: Office of Information Policy
+  email: info@agency.gov
 
 # Build settings
+#
+# You probably don't change these unless you know what you're doing :)
 markdown: kramdown
-theme: minima
-gems:
-  - jekyll-feed
+keep_files:
+  - assets/fonts
+  - assets/img
+  - assets/vendor
+  - assets/js
 exclude:
-  - Gemfile
-  - Gemfile.lock
+  - bin
+  - node_modules
+  - npm-debug.log
+  - package.json
+  - README.md
+  - src

--- a/prototypes/form-wizard/_includes/footer.html
+++ b/prototypes/form-wizard/_includes/footer.html
@@ -1,0 +1,35 @@
+<footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
+    <div class="usa-grid usa-footer-return-to-top">
+      <a href="#">Return to top</a>
+    </div>
+    <div class="usa-footer-primary-section">
+      <div class="usa-grid-full">
+        <nav class="usa-footer-nav usa-width-two-thirds">
+          <ul class="usa-unstyled-list">
+            {% for nav_page in site.pages %}
+              {% if nav_page.title %}
+              <li class="usa-width-one-fourth usa-footer-primary-content">
+                <a class="usa-footer-primary-link" href="{{ nav_page.url | prepend:site.baseurl }}">{{ nav_page.title }}</a>
+              </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </nav>
+        <div class="usa-width-one-sixth usa-footer-primary-content">
+          <p>(800) CALL-GOVT</p>
+        </div>
+        <div class="usa-width-one-sixth usa-footer-primary-content">
+          <a href="mailto:{{ site.agency.email }}">{{ site.agency.email }}</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="usa-footer-secondary_section">
+      <div class="usa-grid">
+        <div class="usa-footer-logo">
+          <img class="usa-footer-slim-logo-img" src="/assets/img/logo-img.png" alt="Logo image">
+          <h3 class="usa-footer-slim-logo-heading">{{ site.agency.name }}</h3>
+        </div>
+      </div>
+    </div>
+  </footer>

--- a/prototypes/form-wizard/_includes/head.html
+++ b/prototypes/form-wizard/_includes/head.html
@@ -1,0 +1,14 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+
+  <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ "/assets/css/custom.css" | prepend: site.baseurl }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <script src="{{ "/assets/vendor/jquery.min.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/assets/vendor/uswds.min.js" | prepend: site.baseurl }}"></script>
+</head>

--- a/prototypes/form-wizard/_includes/header.html
+++ b/prototypes/form-wizard/_includes/header.html
@@ -1,0 +1,37 @@
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-basic" role="banner">
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+          <img src="/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government.</p>
+          <p>This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></p>
+        </div>
+      </header>
+    </div>
+  </div>
+
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <button class="usa-menu-btn">Menu</button>
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">{{ site.title }}</a>
+        </em>
+      </div>
+    </div>
+    <nav role="navigation" class="usa-nav">
+      <button class="usa-nav-close">
+        <img src="/assets/img/close.svg" alt="close">
+      </button>
+      <ul class="usa-nav-primary usa-accordion">
+        {% for my_page in site.pages %}
+          {% if my_page.title %}
+          <li><a class="usa-nav-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/prototypes/form-wizard/_layouts/default.html
+++ b/prototypes/form-wizard/_layouts/default.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+  <body>
+
+    {% include header.html %}
+
+    {{ content }}
+
+    {% include footer.html %}
+
+    {% if page.javascript %}
+    <script src="{{ page.javascript | append:".bundle.js" | prepend:"/assets/js/" | prepend:site.baseurl }}"></script>
+    {% endif %}
+  </body>
+
+</html>

--- a/prototypes/form-wizard/_layouts/page.html
+++ b/prototypes/form-wizard/_layouts/page.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<main class="usa-grid main-content">
+  <div class="usa-width-one-whole">
+    <h1>{{ page.title }}</h1>
+  </div>
+
+  <div class="usa-width-one-whole">
+    {{ content }}
+  </div>
+</main>

--- a/prototypes/form-wizard/_sass/_components.scss
+++ b/prototypes/form-wizard/_sass/_components.scss
@@ -1,0 +1,3 @@
+.main-content {
+  margin-top: 4rem;
+}

--- a/prototypes/form-wizard/_sass/_custom.scss
+++ b/prototypes/form-wizard/_sass/_custom.scss
@@ -1,0 +1,5 @@
+/* _custom.scss
+ *
+ * Add your custom SASS/SCSS styles here. Looking for plain ol' CSS? Check out
+ * `assets/css/custom.css` instead.
+ **/

--- a/prototypes/form-wizard/_sass/_uswds.scss
+++ b/prototypes/form-wizard/_sass/_uswds.scss
@@ -1,0 +1,2 @@
+// Import US Web Design Standards
+@import "../node_modules/uswds/src/stylesheets/all.scss";

--- a/prototypes/form-wizard/about.md
+++ b/prototypes/form-wizard/about.md
@@ -4,12 +4,4 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
-
-You can find the source code for the Jekyll new theme at:
-{% include icon-github.html username="jekyll" %} /
-[minima](https://github.com/jekyll/minima)
-
-You can find the source code for Jekyll at
-{% include icon-github.html username="jekyll" %} /
-[jekyll](https://github.com/jekyll/jekyll)
+This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)

--- a/prototypes/form-wizard/assets/css/custom.css
+++ b/prototypes/form-wizard/assets/css/custom.css
@@ -1,0 +1,5 @@
+/* custom.css
+ *
+ * You can add your CSS rules here. If you're familiar with SASS/SCSS, you
+ * might want to checkout `_sass/_custom.css` instead.
+ **/

--- a/prototypes/form-wizard/assets/css/main.scss
+++ b/prototypes/form-wizard/assets/css/main.scss
@@ -1,0 +1,8 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+@charset "utf-8";
+
+@import "uswds";
+@import "components";
+@import "custom";

--- a/prototypes/form-wizard/bin/build-thirdparty.sh
+++ b/prototypes/form-wizard/bin/build-thirdparty.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+mkdir -p _site/assets/vendor
+
+cp -R node_modules/uswds/src/fonts node_modules/uswds/src/img _site/assets/
+cp node_modules/uswds/dist/js/uswds.min.js _site/assets/vendor/
+cp node_modules/jquery/dist/jquery.min.js _site/assets/vendor/
+
+jekyll build

--- a/prototypes/form-wizard/bin/build-thirdparty.sh
+++ b/prototypes/form-wizard/bin/build-thirdparty.sh
@@ -10,4 +10,4 @@ cp -R node_modules/uswds/src/fonts node_modules/uswds/src/img _site/assets/
 cp node_modules/uswds/dist/js/uswds.min.js _site/assets/vendor/
 cp node_modules/jquery/dist/jquery.min.js _site/assets/vendor/
 
-jekyll build
+bundle exec jekyll build

--- a/prototypes/form-wizard/getting-started.md
+++ b/prototypes/form-wizard/getting-started.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Getting started
+permalink: /getting-started/
+---
+
+You can edit `getting-started.md` to change this page. Jekyll understands many
+formats, including markdown and HTML. To change the [home page]({{ "/"
+| prepend:site.baseurl }}), edit `index.html`.
+
+You can add additional pages by copying the `new-page.html` template and edit
+the `published` attribute in the front matter:
+
+```
+---
+layout: default
+title: Your new page
+permalink: /new-page/
+published: true
+---
+```
+
+
+## SASS/SCSS
+
+Jekyll uses [SASS/SCSS](http://sass-lang.com/) to create CSS. You can add your
+own styles to `_sass/_custom.scss`.
+
+Not familiar with SCSS? No problem, you can just write CSS to `assets/css/custom.css`
+
+
+## Javascript
+
+The index page loads `assets/js/index.js`. Other pages don’t load anything by
+default. You can add the `javascript` to a page’s front matter to load a specific
+file, e.g.
+
+```
+---
+layout: page
+title: Getting started
+javascript: getting-started.js
+---
+```
+
+Will load `assets/js/getting-started.js`.
+
+
+## Helpful resources
+
+If you have trouble, start with the [Jekyll
+documentation](https://jekyllrb.com/docs/home/) which is the main technology
+behind this project.

--- a/prototypes/form-wizard/index.html
+++ b/prototypes/form-wizard/index.html
@@ -1,0 +1,16 @@
+---
+layout: default
+javascript: index
+---
+
+<main class="usa-grid main-content">
+  <div class="usa-width-one-whole">
+    <h1>{{ site.title }}</h1>
+  </div>
+
+  <div class="usa-width-one-whole">
+    <p>Welcome to the FOIA Form Wizard prototype.</p>
+
+    <p>We’ve tried to keep this template as simple as possible to get out of your way. You can learn more on our <a href="{{ "/getting-started" | prepend:site.baseurl }}">getting started page</a>. If you're familiar with <a href="https://jekyllrb.com/">Jekyll</a>, edit <code>index.html</code> to get right to work.</p>
+  </div>
+</main>

--- a/prototypes/form-wizard/index.md
+++ b/prototypes/form-wizard/index.md
@@ -1,6 +1,0 @@
----
-# You don't need to edit this file, it's empty on purpose.
-# Edit theme's home layout instead if you wanna make some changes
-# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-layout: home
----

--- a/prototypes/form-wizard/new-page.html
+++ b/prototypes/form-wizard/new-page.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Your new page
+permalink: /new-page/
+published: false
+---
+
+<!-- add your HTML here -->

--- a/prototypes/form-wizard/package.json
+++ b/prototypes/form-wizard/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build-js && npm run build-thirdparty",
     "build-js": "mkdir -p _site/assets/js && for entrypoint in src/*.js; do bundle_name=$(basename $entrypoint .js); browserify $entrypoint -o _site/assets/js/${bundle_name}.bundle.js; done",
     "build-thirdparty": "bin/build-thirdparty.sh",
-    "serve": "npm run build && jekyll serve",
+    "serve": "npm run build && bundle exec jekyll serve",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/prototypes/form-wizard/package.json
+++ b/prototypes/form-wizard/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "foia-form-wizard",
+  "version": "1.0.0",
+  "description": "A jekyll template for prototyping USWDS based websites.",
+  "main": "index.js",
+  "public": false,
+  "scripts": {
+    "build": "npm run build-js && npm run build-thirdparty",
+    "build-js": "mkdir -p _site/assets/js && for entrypoint in src/*.js; do bundle_name=$(basename $entrypoint .js); browserify $entrypoint -o _site/assets/js/${bundle_name}.bundle.js; done",
+    "build-thirdparty": "bin/build-thirdparty.sh",
+    "serve": "npm run build && jekyll serve",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/18F/foia-recommendations.git"
+  },
+  "author": "",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/18F/foia-recommendations/issues"
+  },
+  "homepage": "https://github.com/18F/foia-recommendations#readme",
+  "dependencies": {
+    "browserify": "^13.0.1",
+    "jquery": "^2.2.3",
+    "uswds": "^1.0.0"
+  }
+}

--- a/prototypes/form-wizard/src/index.js
+++ b/prototypes/form-wizard/src/index.js
@@ -1,0 +1,7 @@
+/* src/index.js
+ *
+ * Add  your custom javascript here. This file is only loaded on the home page
+ * unless you add a `javascript` property to your page's front matter.
+ **/
+
+console.log('hello world');


### PR DESCRIPTION
This leverages some past work I did to use the [US Web Design Standards](https://standards.usa.gov/) in a previous jekyll project.

It uses npm to pull in uswds, and wraps the jekyll cli using `npm run build`, `npm run serve`.
It includes some build scripts to copy the uswds assets around.
It also includes browserify so you can use commonjs style requires for including modules.
It includes jquery which is a depedency of uswds anyway.

I'm not attached to any of the tech included here, this is just the quickest way of getting the web design standards into the project.

**screenshot**
![screenshot from 2017-05-16 14-32-32](https://cloud.githubusercontent.com/assets/509703/26129305/90676586-3a44-11e7-8f4d-a20bacf17865.png)
