### PR TITLE
Simple CI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  node:
+    # https://discuss.circleci.com/t/use-node-version-from-package-json/122/7
+    version: 6.10.3
+
+dependencies:
+  override:
+    - make setup
+
+test:
+  override:
+    - echo ok


### PR DESCRIPTION
Without a config, CI can't detect our app and so fails the build. That's no fun for folks who are getting build failures just for changing markdown, so this simple CI config should just keep the build passing until we have some real tests/checks to run.