### PR TITLE
Continuous deployment configuration for cloud.gov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,8 @@ run:
 	cd prototypes/form-wizard && \
 	npm run serve
 
-.PHONY: build setup run
+test:
+	cd prototypes/form-wizard && \
+	echo ok
+
+.PHONY: build setup run test

--- a/circle.yml
+++ b/circle.yml
@@ -20,4 +20,5 @@ deployment:
       - export PATH=$HOME/bin:$PATH
       - curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.0" | tar xzv -C $HOME/bin
       - cf install-plugin autopilot -f -r CF-Community
+      - prototypes/form-wizard/bin/staticfileauth.sh prototypes/form-wizard/_site/Staticfile.auth
       - prototypes/form-wizard/bin/cf_deploy.sh adborden-foia-auth sandbox-gsa aaron.borden prototypes/form-wizard/manifest.yml

--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,10 @@ test:
 
 deployment:
   prototype:
-    branch: adb-circle
+    branch: master
     commands:
       - export PATH=$HOME/bin:$PATH
       - curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.0" | tar xzv -C $HOME/bin
       - cf install-plugin autopilot -f -r CF-Community
       - prototypes/form-wizard/bin/staticfileauth.sh prototypes/form-wizard/_site/Staticfile.auth
-      - prototypes/form-wizard/bin/cf_deploy.sh adborden-foia-auth sandbox-gsa aaron.borden prototypes/form-wizard/manifest.yml
+      - prototypes/form-wizard/bin/cf_deploy.sh foia-form-wizard doj-foia-discovery prototype prototypes/form-wizard/manifest.yml

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ machine:
 dependencies:
   override:
     - make setup
+  post:
+    - make build
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
   override:
-    - echo ok
+    - make test

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,12 @@ dependencies:
 test:
   override:
     - make test
+
+deployment:
+  prototype:
+    branch: adb-circle
+    commands:
+      - export PATH=$HOME/bin:$PATH
+      - curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.0" | tar xzv -C $HOME/bin
+      - cf install-plugin autopilot -f -r CF-Community
+      - prototypes/form-wizard/bin/cf_deploy.sh adborden-foia-auth sandbox-gsa aaron.borden prototypes/form-wizard/manifest.yml

--- a/prototypes/form-wizard/.gitignore
+++ b/prototypes/form-wizard/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-metadata
 node_modules
 npm-debug.log
+Staticfile.auth

--- a/prototypes/form-wizard/README.md
+++ b/prototypes/form-wizard/README.md
@@ -31,6 +31,26 @@ is checked out at the same directory level as the foia-recommendations repo. You
 override that default by setting the `FOIA_AGENCY_DIR` environment variable
 to wherever you have `2015-foia/contacts/data` located on your local file system.
 
+## Deployment
+
+This prototype is deployed as a static application to
+[cloud.gov](https://cloud.gov/) behind Basic authentication. Team members should
+request the username/passphrase from their teammates.
+
+The Basic authentication is configured via `Staticfile.auth` and is configured
+in our continuous deployment pipeline. The `$STATICAUTHFILE` secret environment
+variable must be set. To create the `$STATICAUTHFILE` hash, use `mkpasswd` or
+`htpasswd` as available.
+
+1. `mkpasswd -m sha-512 "your secret passphrase"`
+   This creates a hash that looks something like
+   `$6$asdfjkl$ljklsajfkldsjakfldjaklfjdskalfdsaljfkdlsaajfkdlsaf`
+2. Prepend the hash with the username and `:`.
+   `userbob:$6$asdfjkl$ljklsajfkldsjakfldjaklfjdskalfdsaljfkdlsaajfkdlsaf`
+3. Set `$STATICAUTHFILE` to this value. Be sure to shell escape it as
+   appropriate. In CircleCI, this means escaping all the `$` characters as `\$`.
+   `userbob:\$6\$asdfjkl\$ljklsajfkldsjakfldjaklfjdskalfdsaljfkdlsaajfkdlsaf`
+
 
 [jekyll-site]: https://jekyllrb.com/
 [node-download]: https://nodejs.org/en/download/

--- a/prototypes/form-wizard/_config.yml
+++ b/prototypes/form-wizard/_config.yml
@@ -31,6 +31,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - bin
+  - manifest.yml
   - node_modules
   - npm-debug.log
   - package.json

--- a/prototypes/form-wizard/bin/cf_deploy.sh
+++ b/prototypes/form-wizard/bin/cf_deploy.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+cloud_gov=${CF_API:-https://api.fr.cloud.gov}
+
+app=${1}
+org=${2}
+space=${3}
+manifest=${4:-manifest.yml}
+
+if [[ -z $org || -z $space || -z $app ]]; then
+  echo "Usage: $0  <app> <org> <space> [manifest.yml]" >&2
+  exit 1
+fi
+
+cf api "$cloud_gov"
+
+(
+  set +x # Disable debugging
+
+  # Log in if necessary
+  if [[ -n $CF_DEPLOY_USER && -n $CF_DEPLOY_PASSWORD ]]; then
+    cf auth "$CF_DEPLOY_USER" "$CF_DEPLOY_PASSWORD"
+  fi
+)
+
+# Target space
+cf target -o "$org" -s "$space"
+
+# If the app exists, use zero-downtime
+if cf app "$app"; then
+  command=zero-downtime-push
+else
+  command=push
+fi
+
+# Deploy web-app
+cf "$command" "$app" -f "$manifest"

--- a/prototypes/form-wizard/bin/staticfileauth.sh
+++ b/prototypes/form-wizard/bin/staticfileauth.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+statifileauth_path=${1:-Staticfile.auth}
+echo "$STATICFILEAUTH" > "$statifileauth_path"

--- a/prototypes/form-wizard/manifest.yml
+++ b/prototypes/form-wizard/manifest.yml
@@ -1,0 +1,5 @@
+---
+buildpack: staticfile_buildpack
+path: _site
+memory: 64M
+name: foia-form-wizard

--- a/prototypes/form-wizard/package.json
+++ b/prototypes/form-wizard/package.json
@@ -25,5 +25,9 @@
     "browserify": "^13.0.1",
     "jquery": "^2.2.3",
     "uswds": "^1.0.0"
+  },
+  "engines": {
+    "node": "6.x.x",
+    "npm": "3.x.x"
   }
 }


### PR DESCRIPTION
This will automatically deploy the `master` branch to cloud.gov, assuming build and tests are successful from CI.

What's left
- [x] waiting on cloud.gov org creation
- [x] configure `CF_DEPLOY_USER` and `CF_DEPLOY_PASSWORD` secrets in CI
- [x] update cd config for any cloud.gov details that may have changed (org/space)