### PR TITLE
Linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ run:
 
 test:
 	cd prototypes/form-wizard && \
-	bundle exec htmlproofer ./_site --check-html --disable-external
+	bundle exec htmlproofer ./_site --check-html --disable-external && \
+	npm test
 
 .PHONY: build setup run test

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ run:
 
 test:
 	cd prototypes/form-wizard && \
-	echo ok
+	bundle exec htmlproofer ./_site --check-html --disable-external
 
 .PHONY: build setup run test

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,4 @@
-build:
-	cd prototypes/form-wizard && \
-	npm run build
-
-setup:
-	cd prototypes/form-wizard && \
-	bundle install && \
-	npm install
-
-run:
-	cd prototypes/form-wizard && \
-	npm run serve
-
-test:
-	cd prototypes/form-wizard && \
-	bundle exec htmlproofer ./_site --check-html --disable-external && \
-	npm test
+build setup run test:
+	$(MAKE) -C prototypes/form-wizard $@
 
 .PHONY: build setup run test

--- a/prototypes/form-wizard/.eslintignore
+++ b/prototypes/form-wizard/.eslintignore
@@ -1,0 +1,2 @@
+_site/
+assets/vendor/

--- a/prototypes/form-wizard/.eslintrc
+++ b/prototypes/form-wizard/.eslintrc
@@ -1,0 +1,8 @@
+---
+extends: airbnb-base/legacy
+globals:
+  $: true
+  Bloodhound: true
+  jQuery: true
+rules:
+  func-names: 0

--- a/prototypes/form-wizard/Gemfile
+++ b/prototypes/form-wizard/Gemfile
@@ -11,6 +11,8 @@ ruby RUBY_VERSION
 # Happy Jekylling!
 gem "jekyll", "3.4.3"
 
+gem 'html-proofer'
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/prototypes/form-wizard/Gemfile.lock
+++ b/prototypes/form-wizard/Gemfile.lock
@@ -1,11 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    colored (1.2)
+    concurrent-ruby (1.0.5)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
+    html-proofer (3.6.0)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.8.1)
     jekyll (3.4.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -27,6 +46,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    mini_portile2 (2.1.0)
+    minitest (5.10.2)
+    nokogiri (1.7.2)
+      mini_portile2 (~> 2.1.0)
+    parallel (1.11.2)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -36,11 +60,18 @@ GEM
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
+    thread_safe (0.3.6)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll (= 3.4.3)
   tzinfo-data
 

--- a/prototypes/form-wizard/Makefile
+++ b/prototypes/form-wizard/Makefile
@@ -1,0 +1,16 @@
+build:
+	npm run build
+
+setup:
+	bundle install
+	npm install
+
+run:
+	npm run serve
+
+test:
+	stat _site/assets/js/agencies.js > /dev/null
+	bundle exec htmlproofer ./_site --check-html --disable-external
+	npm test
+
+.PHONY: build setup run test

--- a/prototypes/form-wizard/_includes/footer.html
+++ b/prototypes/form-wizard/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
-      <a href="#">Return to top</a>
+      <a href="#top">Return to top</a>
     </div>
     <div class="usa-footer-primary-section">
       <div class="usa-grid-full">

--- a/prototypes/form-wizard/_includes/head.html
+++ b/prototypes/form-wizard/_includes/head.html
@@ -7,7 +7,6 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
-  <link rel="stylesheet" href="{{ "/assets/css/custom.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <script src="{{ "/assets/vendor/jquery.min.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/assets/vendor/uswds.min.js" | prepend: site.baseurl }}"></script>

--- a/prototypes/form-wizard/_includes/header.html
+++ b/prototypes/form-wizard/_includes/header.html
@@ -1,5 +1,5 @@
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-<header class="usa-header usa-header-basic" role="banner">
+<header id="top" class="usa-header usa-header-basic" role="banner">
   <div class="usa-banner">
     <div class="usa-accordion">
       <header class="usa-banner-header">

--- a/prototypes/form-wizard/_layouts/page.html
+++ b/prototypes/form-wizard/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<main class="usa-grid main-content">
+<main id="main-content" class="usa-grid main-content">
   <div class="usa-width-one-whole">
     <h1>{{ page.title }}</h1>
   </div>

--- a/prototypes/form-wizard/assets/css/custom.css
+++ b/prototypes/form-wizard/assets/css/custom.css
@@ -1,5 +1,0 @@
-/* custom.css
- *
- * You can add your CSS rules here. If you're familiar with SASS/SCSS, you
- * might want to checkout `_sass/_custom.css` instead.
- **/

--- a/prototypes/form-wizard/index.html
+++ b/prototypes/form-wizard/index.html
@@ -3,7 +3,7 @@ layout: default
 javascript: index
 ---
 
-<main class="usa-grid main-content">
+<main id="main-content" class="usa-grid main-content">
   <div class="usa-width-one-whole">
     <h1>{{ site.title }}</h1>
   </div>

--- a/prototypes/form-wizard/package.json
+++ b/prototypes/form-wizard/package.json
@@ -9,7 +9,7 @@
     "build-js": "mkdir -p _site/assets/js && for entrypoint in src/*.js; do bundle_name=$(basename $entrypoint .js); browserify $entrypoint -o _site/assets/js/${bundle_name}.bundle.js; done",
     "build-thirdparty": "bin/build-thirdparty.sh",
     "serve": "npm run build && bundle exec jekyll serve",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -29,5 +29,10 @@
   "engines": {
     "node": "6.x.x",
     "npm": "3.x.x"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-import": "^1.16.0"
   }
 }

--- a/prototypes/form-wizard/src/foia.js
+++ b/prototypes/form-wizard/src/foia.js
@@ -1,11 +1,12 @@
+/* global AGENCIES */
 var FOIA = {
-  agencyNames: function() {
-    return jQuery.map(AGENCIES, function(el, idx) { return idx }).sort();
+  agencyNames: function () {
+    return jQuery.map(AGENCIES, function (el, idx) { return idx; }).sort();
   }
 };
 
-jQuery(document).ready(function() {
-  $agency = jQuery('#agency');
+jQuery(document).ready(function () {
+  var $agency = jQuery('#agency');
   $agency.typeahead({
     minLength: 2,
     highlight: true

--- a/prototypes/form-wizard/src/index.js
+++ b/prototypes/form-wizard/src/index.js
@@ -3,5 +3,3 @@
  * Add  your custom javascript here. This file is only loaded on the home page
  * unless you add a `javascript` property to your page's front matter.
  **/
-
-console.log('hello world');


### PR DESCRIPTION
- [x] Should be merged _after_ https://github.com/18F/foia-recommendations/pull/41.

Adds [html-proofer](https://github.com/gjtorikian/html-proofer) for the static HTML linting and [eslint](http://eslint.org/) for javascript linting. I've fixed the issues that came up after adding them.