### PR TITLE
Make prototype submission form agency-aware

### DIFF
--- a/prototypes/form-wizard/Makefile
+++ b/prototypes/form-wizard/Makefile
@@ -6,7 +6,7 @@ setup:
 	npm install
 
 run:
-	npm run serve
+	npm run serve --watch
 
 test:
 	stat _site/assets/js/agencies.js > /dev/null

--- a/prototypes/form-wizard/_sass/_custom.scss
+++ b/prototypes/form-wizard/_sass/_custom.scss
@@ -33,3 +33,17 @@ span.twitter-typeahead {
     background-color: #0071bc;
   }
 }
+
+.unified-form {
+  display: none;
+}
+
+.external-link {
+  display: none;
+}
+
+.agency-picker {
+  label {
+    margin-top: 0;
+  }
+}

--- a/prototypes/form-wizard/request.html
+++ b/prototypes/form-wizard/request.html
@@ -4,6 +4,29 @@ title: Create a FOIA request
 permalink: /request/
 ---
 
+<div class="agency-picker">
+<p>
+Begin your federal Freedom of Information Act request by connecting
+with the agency that has the information you're seeking.
+</p>
+
+<form action="#">
+  <fieldset>
+    <label for="agency" class="usa-input-required">Agency name</label>
+    <input id="agency" type="text" size="100">
+  </fieldset>
+</form>
+
+</div>
+
+<div class="external-link">
+<p>
+ You can submit a FOIA request via this link:
+</p>
+<p class="foia-link"></p>
+</div>
+
+<div class="unified-form">
 <p>Here’s where you can create a FOIA request in three steps.</p>
 <ol>
   <li>Enter your contact information.</li>
@@ -44,9 +67,6 @@ permalink: /request/
   <fieldset>
     <legend>Processing details</legend>
 
-    <label for="agency" class="usa-input-required">Agency name</label>
-    <input id="agency" type="text" size="100">
-
     <label for="fees">I’m willing to pay fees up to this amount</label>
     <input id="fees" type="text">
 
@@ -63,3 +83,4 @@ permalink: /request/
     <button id="reset" class="usa-button usa-button-secondary" type="reset">Reset</button>
   </div>
 </form>
+</div>

--- a/prototypes/form-wizard/src/foia.js
+++ b/prototypes/form-wizard/src/foia.js
@@ -1,7 +1,29 @@
+// global methods in our namespace
+// AGENCIES is a global var defined in agencies.js
 /* global AGENCIES */
-var FOIA = {
+var FOIA = {};
+var Agency = require('./models/agency');
+
+FOIA = {
   agencyNames: function () {
     return jQuery.map(AGENCIES, function (el, idx) { return idx; }).sort();
+  },
+  agency: function (name) {
+    return new Agency(AGENCIES[name]);
+  },
+  hideAgencyDetails: function () {
+    $('.external-link').hide();
+    $('.unified-form').hide();
+  },
+  showRequestFormLink: function (agency) {
+    var $link = $('<a class="foia-link"></a>');
+    $link.attr('href', agency.request_form);
+    $link.text(agency.request_form);
+    $('p.foia-link').html($link);
+    $('.external-link').show();
+  },
+  showForm: function () { // TODO agency is passed but not used
+    $('.unified-form').show();
   }
 };
 
@@ -17,5 +39,15 @@ jQuery(document).ready(function () {
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       datumTokenizer: Bloodhound.tokenizers.whitespace
     })
+  });
+  $agency.on('typeahead:select', function (ev, suggestion) {
+    var agency = FOIA.agency(suggestion);
+    FOIA.hideAgencyDetails();
+    // console.log(agency);
+    if (agency.hasRequestForm()) {
+      FOIA.showRequestFormLink(agency);
+    } else {
+      FOIA.showForm(agency);
+    }
   });
 });

--- a/prototypes/form-wizard/src/models/agency.js
+++ b/prototypes/form-wizard/src/models/agency.js
@@ -1,0 +1,12 @@
+/* eslint no-use-before-define: ["error", { "functions": false }] */
+
+module.exports = Agency;
+
+function Agency(attributes) { Object.assign(this, attributes); }
+
+Agency.prototype.hasRequestForm = function () {
+  if (this.request_form) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
**Why**
The form should respond to the agency selected.

**How**
Refactor the request.html page to put the agency picker field first, hiding the form by default. Only show the form if the selected agency does not have an external request form already.