### PR TITLE
Use absolute urls

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ deployment:
   prototype:
     branch: master
     commands:
+      - make dist
       - export PATH=$HOME/bin:$PATH
       - curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.0" | tar xzv -C $HOME/bin
       - cf install-plugin autopilot -f -r CF-Community

--- a/prototypes/form-wizard/Makefile
+++ b/prototypes/form-wizard/Makefile
@@ -3,6 +3,11 @@ agencies:
 
 build:
 	npm run build
+	bundle exec jekyll build
+
+dist:
+	npm run build
+	bundle exec jekyll build --baseurl "https://foia-form-wizard.app.cloud.gov"
 
 setup:
 	bundle install

--- a/prototypes/form-wizard/_config.yml
+++ b/prototypes/form-wizard/_config.yml
@@ -13,7 +13,7 @@ title: FOIA request prototype
 description: > # this means to ignore newlines until "baseurl:"
   A prototype exploring how the public might submit a FOIA request through
   a single national portal.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "https://foia-form-wizard.app.cloud.gov" # the subpath of your site, e.g. /blog
 agency:
   name: Office of Information Policy
   email: info@agency.gov

--- a/prototypes/form-wizard/_config.yml
+++ b/prototypes/form-wizard/_config.yml
@@ -13,7 +13,7 @@ title: FOIA request prototype
 description: > # this means to ignore newlines until "baseurl:"
   A prototype exploring how the public might submit a FOIA request through
   a single national portal.
-baseurl: "https://foia-form-wizard.app.cloud.gov" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 agency:
   name: Office of Information Policy
   email: info@agency.gov

--- a/prototypes/form-wizard/_includes/footer.html
+++ b/prototypes/form-wizard/_includes/footer.html
@@ -27,7 +27,7 @@
     <div class="usa-footer-secondary_section">
       <div class="usa-grid">
         <div class="usa-footer-logo">
-          <img class="usa-footer-slim-logo-img" src="/assets/img/logo-img.png" alt="Logo image">
+          <img class="usa-footer-slim-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
           <h3 class="usa-footer-slim-logo-heading">{{ site.agency.name }}</h3>
         </div>
       </div>

--- a/prototypes/form-wizard/_includes/header.html
+++ b/prototypes/form-wizard/_includes/header.html
@@ -4,7 +4,7 @@
     <div class="usa-accordion">
       <header class="usa-banner-header">
         <div class="usa-grid usa-banner-inner">
-          <img src="/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
           <p>An official website of the United States government.</p>
           <p>This site is currently in discovery. <a href="https://18f.gsa.gov/dashboard/stages/#discovery">Learn more.</a></p>
         </div>
@@ -23,7 +23,7 @@
     </div>
     <nav role="navigation" class="usa-nav">
       <button class="usa-nav-close">
-        <img src="/assets/img/close.svg" alt="close">
+        <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
       </button>
       <ul class="usa-nav-primary usa-accordion">
         {% for my_page in site.pages %}

--- a/prototypes/form-wizard/bin/build-thirdparty.sh
+++ b/prototypes/form-wizard/bin/build-thirdparty.sh
@@ -9,5 +9,3 @@ mkdir -p _site/assets/vendor
 cp -R node_modules/uswds/src/fonts node_modules/uswds/src/img _site/assets/
 cp node_modules/uswds/dist/js/uswds.min.js _site/assets/vendor/
 cp node_modules/jquery/dist/jquery.min.js _site/assets/vendor/
-
-bundle exec jekyll build


### PR DESCRIPTION
When sharing a url that includes the user/pass, Chrome blocks some assets in an
attempt to hide the creds. By using absolute urls, we can use a link with
user/pass to auth the user and all assets won't leak any information.