### PR TITLE
Use placeholder text in agency name input

### DIFF
--- a/prototypes/form-wizard/request.html
+++ b/prototypes/form-wizard/request.html
@@ -28,7 +28,7 @@ permalink: /request/
 <form action="#">
   <fieldset>
     <label for="agency" class="usa-input-required">Agency name</label>
-    <input id="agency" type="text">
+    <input id="agency" type="text" placeholder="Type agency name here">
   </fieldset>
 </form>
 


### PR DESCRIPTION
Be explicit about typing the agency name