### PR TITLE
Send FOIAonline agencies directly to form

### DIFF
--- a/prototypes/form-wizard/src/foia.js
+++ b/prototypes/form-wizard/src/foia.js
@@ -5,6 +5,7 @@ var FOIA = {};
 var Agency = require('./models/agency');
 
 FOIA = {
+  FOIAonlineForm: 'https://foiaonline.regulations.gov/foia/action/public/request/createRequest',
   agencyNames: function () {
     return jQuery.map(AGENCIES, function (el, idx) { return idx; }).sort();
   },
@@ -18,7 +19,11 @@ FOIA = {
   },
   showRequestFormLink: function (agency) {
     var $link = $('a.foia-link');
-    $link.attr('href', agency.request_form);
+    var href = agency.request_form;
+    if (agency.isFOIAonline()) {
+      href = FOIA.FOIAonlineForm;
+    }
+    $link.attr('href', href);
     $('.external-link').show();
   },
   showForm: function () { // TODO agency is passed but not used

--- a/prototypes/form-wizard/src/models/agency.js
+++ b/prototypes/form-wizard/src/models/agency.js
@@ -10,3 +10,7 @@ Agency.prototype.hasRequestForm = function () {
   }
   return false;
 };
+
+Agency.prototype.isFOIAonline = function () {
+  return this.request_form.match(/foiaonline/);
+};


### PR DESCRIPTION
Bypass the home page and guest/login choice pages,
and link directly to the form.