### PR TITLE
Fix linting

### DIFF
--- a/prototypes/form-wizard/package.json
+++ b/prototypes/form-wizard/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.7.0",
     "npm-run-all": "^4.0.2",
     "watch": "^1.0.2"
   }

--- a/prototypes/form-wizard/src/index.js
+++ b/prototypes/form-wizard/src/index.js
@@ -2,4 +2,4 @@
  *
  * Add  your custom javascript here. This file is only loaded on the home page
  * unless you add a `javascript` property to your page's front matter.
- **/
+ */


### PR DESCRIPTION
Our eslint config from airbnb isn't quite backwards compatible. Update packages
and fix linting for eslint-config-airbnb-base@11.3.x