### PR TITLE
Remove CircleCI notice, not attended to anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CircleCI](https://circleci.com/gh/18F/foia-recommendations.svg?style=svg)](https://circleci.com/gh/18F/foia-recommendations)
-
 # National FOIA Site Research and Recommendations
 
 ## About


### PR DESCRIPTION
This removes the `FAILED` notice for CircleCI at the top of the README. To a layperson visiting the report, the context-free `FAILED` is a weird intro and could give the impression the report is describing a failure.